### PR TITLE
fix(domain/ts): compute averagePriceBrl from totalCostBrl/quantity

### DIFF
--- a/web/src/domain/entities/portfolio/PortfolioPosition.ts
+++ b/web/src/domain/entities/portfolio/PortfolioPosition.ts
@@ -39,22 +39,23 @@ export class PortfolioPosition {
   }
 
   /**
-   * Calculate average price in BRL using a given PTAX bid rate
-   * @param ptaxBid - The PTAX buy rate to use for conversion
+   * Calculate average price in BRL from accumulated BRL cost basis.
+   * Uses totalCostBrl / quantity so the result correctly reflects the
+   * weighted average across all vestings at their respective PTAX rates,
+   * rather than re-converting the USD average with a single spot rate.
    */
-  averagePriceBrl(ptaxBid: number): Money {
-    if (ptaxBid <= 0) {
-      throw new Error('PTAX bid rate must be positive');
-    }
-    return new Money(this.averagePriceUsd.amount * ptaxBid, 'BRL');
+  averagePriceBrl(): Money {
+    return new Money(
+      this.quantity.value > 0 ? this.totalCostBrl.amount / this.quantity.value : 0,
+      'BRL'
+    );
   }
 
   /**
    * Calculate average price per share
    * @param currency - Currency to calculate in ('USD' or 'BRL')
-   * @param ptaxBid - Required if currency is 'BRL'
    */
-  calculateAveragePrice(currency: string, ptaxBid?: number): Money {
+  calculateAveragePrice(currency: string): Money {
     if (this.isEmpty) {
       return new Money(0, currency);
     }
@@ -62,10 +63,7 @@ export class PortfolioPosition {
     if (currency === 'USD') {
       return new Money(this.totalCostUsd.amount / this.quantity.value, 'USD');
     } else if (currency === 'BRL') {
-      if (ptaxBid === undefined) {
-        throw new Error('PTAX bid rate is required to calculate BRL average price');
-      }
-      return this.averagePriceBrl(ptaxBid);
+      return this.averagePriceBrl();
     } else {
       throw new Error(`Unsupported currency: ${currency}`);
     }

--- a/web/src/domain/entities/snapshots/PortfolioSnapshot.ts
+++ b/web/src/domain/entities/snapshots/PortfolioSnapshot.ts
@@ -26,8 +26,6 @@ export class PortfolioSnapshot implements CSVExportable, PDFExportable, JSONExpo
    * Export to CSV row format
    */
   toCSVRow(): string[] {
-    const ptaxBid = this.metadata.exchangeRates.ptaxBid;
-    
     return [
       this.formatDate(this.metadata.operationDate),
       this.getOperationDescription(),
@@ -36,7 +34,7 @@ export class PortfolioSnapshot implements CSVExportable, PDFExportable, JSONExpo
       this.position.totalCostUsd.amount.toFixed(4),
       this.position.averagePriceUsd.amount.toFixed(4),
       this.position.totalCostBrl.amount.toFixed(4),
-      this.position.averagePriceBrl(ptaxBid).amount.toFixed(4),
+      this.position.averagePriceBrl().amount.toFixed(4),
       this.position.grossProfitBrl.amount.toFixed(4),
     ];
   }

--- a/web/src/domain/operations/__tests__/VestingOperation.test.ts
+++ b/web/src/domain/operations/__tests__/VestingOperation.test.ts
@@ -46,6 +46,7 @@ describe('VestingOperation', () => {
     expect(result.position.totalCostUsd.amount).toBe(1500);
     expect(result.position.totalCostBrl.amount).toBe(7500);
     expect(result.position.averagePriceUsd.amount).toBe(15);
+    expect(result.position.averagePriceBrl().amount).toBe(75); // 7500 / 100
     expect(result.hasProfitLoss).toBe(false);
   });
 
@@ -81,6 +82,35 @@ describe('VestingOperation', () => {
     );
 
     expect(operation.getDescription()).toBe('Vesting: +100 shares at $15.5000');
+  });
+
+  it('averagePriceBrl uses accumulated BRL cost, not USD average re-converted at spot rate', () => {
+    // Vesting 1: 100 shares @ $10 with PTAX 5.0 → BRL cost R$5,000
+    const date1 = new Date('2023-01-15');
+    const op1 = new VestingOperation(new Date('2023-01-15'), new StockQuantity(100), new Money(10, 'USD'));
+    const emptyPosition = new PortfolioPosition(
+      new StockQuantity(0),
+      new Money(0, 'USD'),
+      new Money(0, 'BRL'),
+      new Money(0, 'USD'),
+      new ProfitLoss(0, 'BRL'),
+      date1
+    );
+    const rate1 = new ExchangeRate('USD', 'BRL', date1, 5.0, 5.0);
+    const afterFirst = op1.execute(emptyPosition, rate1);
+
+    // Vesting 2: 100 shares @ $10 with PTAX 6.0 → BRL cost R$6,000
+    const date2 = new Date('2023-06-15');
+    const op2 = new VestingOperation(date2, new StockQuantity(100), new Money(10, 'USD'));
+    const rate2 = new ExchangeRate('USD', 'BRL', date2, 6.0, 6.0);
+    const afterSecond = op2.execute(afterFirst.position, rate2);
+
+    // totalCostBrl = R$5,000 + R$6,000 = R$11,000; quantity = 200
+    // correct averagePriceBrl = R$11,000 / 200 = R$55.00
+    // wrong (old) formula: $10 × PTAX 6.0 = R$60.00
+    expect(afterSecond.position.totalCostBrl.amount).toBe(11000);
+    expect(afterSecond.position.quantity.value).toBe(200);
+    expect(afterSecond.position.averagePriceBrl().amount).toBe(55);
   });
 });
 

--- a/web/src/infrastructure/services/CSVExportService.ts
+++ b/web/src/infrastructure/services/CSVExportService.ts
@@ -50,15 +50,14 @@ export class CSVExportService implements IDataExportService {
       .sort(([a], [b]) => a - b)
       .map(([year, snapshot]) => {
         const position = snapshot.position;
-        const ptaxBid = snapshot.metadata.exchangeRates.ptaxBid;
-        
+
         return [
           year.toString(),
           position.quantity.value.toString(),
           position.totalCostUsd.amount.toFixed(4),
           position.averagePriceUsd.amount.toFixed(4),
           position.totalCostBrl.amount.toFixed(4),
-          position.averagePriceBrl(ptaxBid).amount.toFixed(4),
+          position.averagePriceBrl().amount.toFixed(4),
           position.grossProfitBrl.amount.toFixed(4),
         ];
       });

--- a/web/src/presentation/ModalBuilder.ts
+++ b/web/src/presentation/ModalBuilder.ts
@@ -90,8 +90,8 @@ export class ModalBuilder {
         • Ações antes: ${previousQty}<br>
         • Ações adicionadas: +${operationQty}<br>
         • Ações após: <strong>${position.quantity.value}</strong><br>
-        • Novo preço médio: ${USDFormatter.formatWithPrecision(position.averagePriceUsd.amount)} 
-        (${BRLFormatter.formatWithPrecision(position.averagePriceBrl(ptaxBid).amount)})<br>
+        • Novo preço médio: ${USDFormatter.formatWithPrecision(position.averagePriceUsd.amount)}
+        (${BRLFormatter.formatWithPrecision(position.averagePriceBrl().amount)})<br>
         • Custo total acumulado: ${BRLFormatter.format(position.totalCostBrl.amount)}
       `;
     } else {
@@ -191,7 +191,7 @@ export class ModalBuilder {
           </div>
           <div class="detail-item">
             <label>Preço Médio (BRL)</label>
-            <div class="value">${BRLFormatter.formatWithPrecision(position.averagePriceBrl(ptaxBid).amount)}</div>
+            <div class="value">${BRLFormatter.formatWithPrecision(position.averagePriceBrl().amount)}</div>
           </div>
           <div class="detail-item">
             <label>PTAX Compra</label>
@@ -199,8 +199,8 @@ export class ModalBuilder {
           </div>
         </div>
         <div class="calculation-detail">
-          <div class="formula">Preço Médio BRL = Preço Médio USD × PTAX Compra</div>
-          ${BRLFormatter.formatWithPrecision(position.averagePriceBrl(ptaxBid).amount)} = ${USDFormatter.formatWithPrecision(position.averagePriceUsd.amount)} × ${ptaxBid.toFixed(6)}
+          <div class="formula">Preço Médio BRL = Custo Total BRL ÷ Quantidade</div>
+          ${BRLFormatter.formatWithPrecision(position.averagePriceBrl().amount)} = ${BRLFormatter.formatWithPrecision(position.totalCostBrl.amount)} ÷ ${position.quantity.value}
         </div>
       </div>
     `;

--- a/web/src/presentation/PortfolioApp.ts
+++ b/web/src/presentation/PortfolioApp.ts
@@ -339,7 +339,6 @@ export class PortfolioApp {
       .map((year) => {
         const snapshot = yearlySnapshots.get(year)!;
         const position = snapshot.position;
-        const ptaxBid = snapshot.metadata.exchangeRates.ptaxBid;
         return `
         <tr data-year="${year}" style="cursor: pointer;">
           <td>${year}</td>
@@ -347,7 +346,7 @@ export class PortfolioApp {
           <td>${USDFormatter.format(position.totalCostUsd.amount)}</td>
           <td>${USDFormatter.formatWithPrecision(position.averagePriceUsd.amount)}</td>
           <td>${BRLFormatter.format(position.totalCostBrl.amount)}</td>
-          <td>${BRLFormatter.formatWithPrecision(position.averagePriceBrl(ptaxBid).amount)}</td>
+          <td>${BRLFormatter.formatWithPrecision(position.averagePriceBrl().amount)}</td>
           <td class="${position.grossProfitBrl.amount >= 0 ? 'positive' : 'negative'}">
             ${BRLFormatter.format(position.grossProfitBrl.amount)}
           </td>
@@ -382,15 +381,14 @@ export class PortfolioApp {
         const position = snapshot.position;
         const metadata = snapshot.metadata;
         const operationDesc = snapshot.getOperationDescription();
-        const ptaxBid = metadata.exchangeRates.ptaxBid;
-        
+
         return `
         <tr data-operation-index="${index}">
           <td>${DateFormatter.format(metadata.operationDate)}</td>
           <td>${operationDesc}</td>
           <td>${position.quantity.value}</td>
           <td>${USDFormatter.formatWithPrecision(position.averagePriceUsd.amount)}</td>
-          <td>${BRLFormatter.formatWithPrecision(position.averagePriceBrl(ptaxBid).amount)}</td>
+          <td>${BRLFormatter.formatWithPrecision(position.averagePriceBrl().amount)}</td>
           <td class="${position.grossProfitBrl.amount >= 0 ? 'positive' : 'negative'}">
             ${BRLFormatter.format(position.grossProfitBrl.amount)}
           </td>

--- a/web/src/presentation/YearDetailsBuilder.ts
+++ b/web/src/presentation/YearDetailsBuilder.ts
@@ -74,7 +74,6 @@ export class YearDetailsBuilder {
     const initialQty = initialPosition?.quantity.value ?? 0;
     const finalQty = finalPosition.quantity.value;
     const netChange = finalQty - initialQty;
-    const ptaxBid = snapshots[snapshots.length - 1]!.metadata.exchangeRates.ptaxBid;
 
     const currentYear = new Date().getFullYear();
     const isCurrentYear = year === currentYear;
@@ -190,7 +189,7 @@ export class YearDetailsBuilder {
           
           <div class="summary-card">
             <div class="summary-label">Preço Médio Final (BRL)</div>
-            <div class="summary-value">${BRLFormatter.formatWithPrecision(finalPosition.averagePriceBrl(ptaxBid).amount)}</div>
+            <div class="summary-value">${BRLFormatter.formatWithPrecision(finalPosition.averagePriceBrl().amount)}</div>
             <div class="summary-detail">Por ação</div>
           </div>
         </div>
@@ -203,7 +202,6 @@ export class YearDetailsBuilder {
       .map((snapshot) => {
         const metadata = snapshot.metadata;
         const position = snapshot.position;
-        const ptaxBid = metadata.exchangeRates.ptaxBid;
         const operationDesc = snapshot.getOperationDescription();
         const profitLoss = snapshot.getOperationProfitLoss();
 
@@ -215,7 +213,7 @@ export class YearDetailsBuilder {
           <td>${USDFormatter.formatWithPrecision(metadata.pricePerShareUsd.amount)}</td>
           <td>${position.quantity.value}</td>
           <td>${USDFormatter.formatWithPrecision(position.averagePriceUsd.amount)}</td>
-          <td>${BRLFormatter.formatWithPrecision(position.averagePriceBrl(ptaxBid).amount)}</td>
+          <td>${BRLFormatter.formatWithPrecision(position.averagePriceBrl().amount)}</td>
           <td class="${profitLoss && profitLoss.amount >= 0 ? 'positive' : profitLoss ? 'negative' : ''}">
             ${profitLoss ? BRLFormatter.format(profitLoss.amount) : '-'}
           </td>
@@ -255,9 +253,8 @@ export class YearDetailsBuilder {
     const finalPosition = lastSnapshot?.position;
     const totalCostBrl = finalPosition?.totalCostBrl.amount ?? 0;
     const totalCostUsd = finalPosition?.totalCostUsd.amount ?? 0;
-    const ptaxBid = lastSnapshot?.metadata.exchangeRates.ptaxBid ?? 0;
     const finalQty = finalPosition?.quantity.value ?? 0;
-    const avgPriceBrl = finalPosition ? finalPosition.averagePriceBrl(ptaxBid).amount : 0;
+    const avgPriceBrl = finalPosition ? finalPosition.averagePriceBrl().amount : 0;
     const avgPriceUsd = finalPosition ? finalPosition.averagePriceUsd.amount : 0;
     const currentYear = new Date().getFullYear();
     const isCurrentYear = year === currentYear;


### PR DESCRIPTION
## Summary

`PortfolioPosition.averagePriceBrl()` was re-converting the USD weighted average using a single spot PTAX rate from the most recent operation:

```typescript
// Before (wrong)
averagePriceBrl(ptaxBid: number): Money {
  return new Money(this.averagePriceUsd.amount * ptaxBid, 'BRL');
}
```

This diverges from the true BRL cost basis whenever shares were vested at **different PTAX rates**. The correct formula is `totalCostBrl / quantity` — the accumulated BRL cost is already tracked precisely on `PortfolioPosition` but was unused.

## Root cause

The BRL cost for each vesting is accumulated correctly into `totalCostBrl` at each operation's actual PTAX rate. However, `averagePriceBrl()` ignored this field and instead multiplied `averagePriceUsd` (the USD weighted average) by a single spot rate, which is only correct if every vesting happened at the same rate.

## Impact

For IRPF declarations, the BRL average price per share diverges from the true cost basis when vestings occur across different dates (e.g. annual or quarterly grants over multiple years with different PTAX rates).

## Formula before/after

| | Formula |
|---|---|
| **Before** | `averagePriceBrl = averagePriceUsd × ptaxBid` |
| **After** | `averagePriceBrl = totalCostBrl ÷ quantity` |

## Concrete numeric example

| Vesting | Shares | Price (USD) | PTAX | BRL cost |
|---------|--------|-------------|------|----------|
| 1 | 100 | $10 | 5.0 | R$5,000 |
| 2 | 100 | $10 | 6.0 | R$6,000 |
| **Total** | **200** | | | **R$11,000** |

- **Correct** `averagePriceBrl` = R$11,000 ÷ 200 = **R$55.00**
- **Old (wrong)** result using last PTAX = $10 × 6.0 = **R$60.00** — a 9% overstatement

## Changes

- **`PortfolioPosition.ts`** — new `averagePriceBrl()` implementation, `ptaxBid` parameter removed; `calculateAveragePrice()` updated accordingly
- **`PortfolioSnapshot.ts`**, **`CSVExportService.ts`**, **`PortfolioApp.ts`**, **`YearDetailsBuilder.ts`**, **`ModalBuilder.ts`** — all 8 call sites updated to drop the now-removed argument
- **`ModalBuilder.ts`** — formula tooltip updated: `Custo Total BRL ÷ Quantidade` (was `Preço Médio USD × PTAX Compra`)
- **`VestingOperation.test.ts`** — new multi-rate vesting test asserting R$55.00; existing test extended with `averagePriceBrl()` assertion

Note: the Python-side equivalent is fixed separately in PR #18.

## Test plan

- [x] `npm test` — all 71 tests pass
- [x] `npm run lint` — no errors
- [x] Multi-rate scenario: two vestings at PTAX 5.0 and 6.0 → `averagePriceBrl()` = R$55.00 ✓
- [x] Single-rate scenario unchanged: 100 shares @ $15, PTAX 5.0 → `averagePriceBrl()` = R$75.00 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)