### PR TITLE
Extend yearly_summary.csv with yearDetails columns

### DIFF
--- a/src/application/services/YearSummary.ts
+++ b/src/application/services/YearSummary.ts
@@ -1,0 +1,166 @@
+import type { PortfolioSnapshot } from '../../domain/entities';
+
+/**
+ * Summary of portfolio activity and IRPF data for a single year.
+ * Used by the Detalhes do Ano modal and the yearly_summary CSV export.
+ */
+export interface YearSummary {
+  readonly year: number;
+  readonly totalOperations: number;
+  readonly totalVested: number;
+  readonly totalSold: number;
+  readonly netChange: number;
+  readonly initialQty: number;
+  readonly finalQty: number;
+  readonly totalCostBrl: number;
+  readonly totalCostUsd: number;
+  readonly totalProfitLoss: number;
+  readonly totalSaleRevenue: number;
+  readonly totalCostBasis: number;
+  readonly avgPtaxAsk: number;
+  readonly finalAvgPriceUsd: number;
+  readonly finalAvgPriceBrl: number;
+  readonly yearInProgress: boolean;
+  readonly isCurrentYear: boolean;
+  readonly vestingCount: number;
+  readonly tradeCount: number;
+  /** IRPF copyable fields (same text as in the modal) */
+  readonly irpfBensEDireitos: string;
+  readonly irpfLocalizacao: string;
+  readonly irpfDiscriminacao: string;
+  readonly irpfNegociadoEmBolsa: string;
+  readonly irpfCodigoNegociacao: string;
+  readonly irpfSituacao3112: string;
+  readonly irpfLucroOuPrejuizo: string;
+}
+
+function formatBrl(value: number): string {
+  return new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function formatBrlPrecision(value: number): string {
+  const needsPrecision = Math.abs(value - Math.floor(value)) > 0.01;
+  return new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+    minimumFractionDigits: needsPrecision ? 4 : 2,
+    maximumFractionDigits: needsPrecision ? 4 : 2,
+  }).format(value);
+}
+
+function formatUsd(value: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function formatUsdPrecision(value: number): string {
+  const needsPrecision = Math.abs(value - Math.floor(value)) > 0.01;
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: needsPrecision ? 4 : 2,
+    maximumFractionDigits: needsPrecision ? 4 : 2,
+  }).format(value);
+}
+
+/**
+ * Compute year-level summary and IRPF strings from snapshots for a given year.
+ * Returns null if yearSnapshots is empty or first/last snapshot is missing.
+ */
+export function computeYearSummary(
+  year: number,
+  yearSnapshots: PortfolioSnapshot[]
+): YearSummary | null {
+  if (yearSnapshots.length === 0) return null;
+
+  const firstSnapshot = yearSnapshots[0];
+  const lastSnapshot = yearSnapshots[yearSnapshots.length - 1];
+  if (!firstSnapshot || !lastSnapshot) return null;
+
+  const finalPosition = lastSnapshot.position;
+  const initialPosition = firstSnapshot.previousPosition;
+
+  const vestings = yearSnapshots.filter((s) => s.metadata.isVesting);
+  const trades = yearSnapshots.filter((s) => s.metadata.isTrade);
+
+  const totalVested = vestings.reduce((sum, s) => sum + s.metadata.quantity.value, 0);
+  const totalSold = trades.reduce((sum, s) => sum + s.metadata.quantity.value, 0);
+
+  const totalProfitLoss = trades.reduce(
+    (sum, s) => sum + (s.metadata.tradeFinancials?.profitLossBrl.amount ?? 0),
+    0
+  );
+  const totalSaleRevenue = trades.reduce(
+    (sum, t) => sum + (t.metadata.tradeFinancials?.saleRevenueBrl.amount ?? 0),
+    0
+  );
+  const totalCostBasis = trades.reduce(
+    (sum, t) => sum + (t.metadata.tradeFinancials?.costBasisBrl.amount ?? 0),
+    0
+  );
+
+  const avgPtaxAsk =
+    yearSnapshots.reduce((sum, s) => sum + s.metadata.exchangeRates.ptaxAsk, 0) /
+    yearSnapshots.length;
+
+  const initialQty = initialPosition?.quantity.value ?? 0;
+  const finalQty = finalPosition.quantity.value;
+  const netChange = finalQty - initialQty;
+
+  const currentYear = new Date().getFullYear();
+  const isCurrentYear = year === currentYear;
+  const isFutureYear = year > currentYear;
+  const yearInProgress = isCurrentYear || isFutureYear;
+
+  const totalCostBrl = finalPosition.totalCostBrl.amount;
+  const totalCostUsd = finalPosition.totalCostUsd.amount;
+  const finalAvgPriceUsd = finalPosition.averagePriceUsd.amount;
+  const finalAvgPriceBrl = finalPosition.averagePriceBrl.amount;
+
+  const irpfBensEDireitos =
+    'Grupo 03 - Participações em sociedades, Código 01 - Ações (inclusive as listadas em bolsa)';
+  const irpfLocalizacao = '137 - Cayman, Ilhas';
+  const irpfDiscriminacao = `NU - ${finalQty} Ações da empresa Nu Holdings Ltd. negociadas na Bolsa dos Estados Unidos através do código: NU, adquiridas pela corretora ETrade. Valor de custo em ${formatUsd(totalCostUsd)} ou ${formatBrl(totalCostBrl)} com preço médio de ${formatUsdPrecision(finalAvgPriceUsd)} ou ${formatBrlPrecision(finalAvgPriceBrl)} por ação.`;
+  const irpfNegociadoEmBolsa = 'Sim';
+  const irpfCodigoNegociacao = 'NU';
+  const irpfSituacao3112 = formatBrl(totalCostBrl);
+  const irpfLucroOuPrejuizo = formatBrl(totalProfitLoss);
+
+  return {
+    year,
+    totalOperations: yearSnapshots.length,
+    totalVested,
+    totalSold,
+    netChange,
+    initialQty,
+    finalQty,
+    totalCostBrl,
+    totalCostUsd,
+    totalProfitLoss,
+    totalSaleRevenue,
+    totalCostBasis,
+    avgPtaxAsk,
+    finalAvgPriceUsd,
+    finalAvgPriceBrl,
+    yearInProgress,
+    isCurrentYear,
+    vestingCount: vestings.length,
+    tradeCount: trades.length,
+    irpfBensEDireitos,
+    irpfLocalizacao,
+    irpfDiscriminacao,
+    irpfNegociadoEmBolsa,
+    irpfCodigoNegociacao,
+    irpfSituacao3112,
+    irpfLucroOuPrejuizo,
+  };
+}

--- a/src/application/services/__tests__/YearSummary.test.ts
+++ b/src/application/services/__tests__/YearSummary.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { computeYearSummary } from '../YearSummary';
+import { ProcessPortfolioUseCase } from '../../usecases/ProcessPortfolioUseCase';
+import { PortfolioCalculationService } from '../../../domain/services/PortfolioCalculationService';
+import { PortfolioAnalyticsService } from '../../../domain/services/PortfolioAnalyticsService';
+import { MockExchangeRateService } from '../../../infrastructure/services/MockExchangeRateService';
+import { JSONOperationRepository } from '../../../infrastructure/repositories/JSONOperationRepository';
+
+function makeUseCase(ops: string) {
+  const opRepo = new JSONOperationRepository(ops);
+  const exchangeService = new MockExchangeRateService(5.0);
+  const calcService = new PortfolioCalculationService(exchangeService);
+  const analyticsService = new PortfolioAnalyticsService();
+  return new ProcessPortfolioUseCase(opRepo, calcService, analyticsService);
+}
+
+describe('computeYearSummary', () => {
+  it('returns null for empty yearSnapshots', () => {
+    expect(computeYearSummary(2023, [])).toBeNull();
+  });
+
+  it('returns summary for year with only vestings', async () => {
+    const json = JSON.stringify([
+      { type: 'vesting', date: '01/15/2023', quantity: 100, price: 10 },
+    ]);
+    const uc = makeUseCase(json);
+    const { snapshots } = await uc.execute({});
+    const summary = computeYearSummary(2023, snapshots);
+
+    expect(summary).not.toBeNull();
+    expect(summary!.year).toBe(2023);
+    expect(summary!.totalOperations).toBe(1);
+    expect(summary!.totalVested).toBe(100);
+    expect(summary!.totalSold).toBe(0);
+    expect(summary!.netChange).toBe(100);
+    expect(summary!.initialQty).toBe(0);
+    expect(summary!.finalQty).toBe(100);
+    expect(summary!.vestingCount).toBe(1);
+    expect(summary!.tradeCount).toBe(0);
+    expect(summary!.irpfBensEDireitos).toContain('Participações em sociedades');
+    expect(summary!.irpfLocalizacao).toBe('137 - Cayman, Ilhas');
+    expect(summary!.irpfCodigoNegociacao).toBe('NU');
+  });
+
+  it('returns summary for year with vestings and trades', async () => {
+    const json = JSON.stringify([
+      { type: 'vesting', date: '01/15/2023', quantity: 100, price: 10 },
+      { type: 'trade', date: '06/10/2023', quantity: 50, price: 15 },
+    ]);
+    const uc = makeUseCase(json);
+    const { snapshots } = await uc.execute({});
+    const summary = computeYearSummary(2023, snapshots);
+
+    expect(summary).not.toBeNull();
+    expect(summary!.year).toBe(2023);
+    expect(summary!.totalOperations).toBe(2);
+    expect(summary!.totalVested).toBe(100);
+    expect(summary!.totalSold).toBe(50);
+    expect(summary!.netChange).toBe(50);
+    expect(summary!.initialQty).toBe(0);
+    expect(summary!.finalQty).toBe(50);
+    expect(summary!.vestingCount).toBe(1);
+    expect(summary!.tradeCount).toBe(1);
+    expect(summary!.totalSaleRevenue).toBeGreaterThanOrEqual(0);
+    expect(summary!.totalCostBasis).toBeGreaterThanOrEqual(0);
+    expect(summary!.irpfDiscriminacao).toContain('Nu Holdings');
+    expect(summary!.irpfDiscriminacao).toContain('ETrade');
+  });
+});

--- a/src/application/services/index.ts
+++ b/src/application/services/index.ts
@@ -1,0 +1,1 @@
+export { computeYearSummary, type YearSummary } from './YearSummary';

--- a/src/infrastructure/services/CSVExportService.ts
+++ b/src/infrastructure/services/CSVExportService.ts
@@ -70,14 +70,14 @@ export class CSVExportService implements IDataExportService {
       'Lucro ou Prejuízo',
     ];
 
-    const rows = Array.from(yearlySnapshots.entries())
+    const rows: string[][] = Array.from(yearlySnapshots.entries())
       .sort(([a], [b]) => a - b)
-      .map(([year, lastSnapshot]) => {
+      .map(([year, lastSnapshot]): string[] => {
         const yearSnapshotsList = snapshotsByYear.get(year) ?? [lastSnapshot];
         const summary = computeYearSummary(year, yearSnapshotsList);
 
         const position = lastSnapshot.position;
-        const baseRow = [
+        const baseRow: string[] = [
           year.toString(),
           position.quantity.value.toString(),
           position.totalCostUsd.amount.toFixed(4),
@@ -88,7 +88,7 @@ export class CSVExportService implements IDataExportService {
         ];
 
         if (!summary) {
-          const emptyCells = new Array(headers.length - baseRow.length).fill('');
+          const emptyCells: string[] = new Array<string>(headers.length - baseRow.length).fill('');
           return [...baseRow, ...emptyCells];
         }
 

--- a/src/infrastructure/services/CSVExportService.ts
+++ b/src/infrastructure/services/CSVExportService.ts
@@ -1,14 +1,15 @@
 import { PortfolioSnapshot } from '../../domain/entities';
 import { IDataExportService } from '../../application/interfaces';
+import { computeYearSummary } from '../../application/services';
 import { PortfolioSnapshotSerializer } from '../adapters/PortfolioSnapshotSerializer';
 
 /**
  * CSV Export Service
- * 
+ *
  * Exports portfolio data to CSV format.
  * Generates two files:
  * 1. Portfolio history (all operations)
- * 2. Yearly summary (final position per year)
+ * 2. Yearly summary (final position per year, with year-detail columns)
  */
 export class CSVExportService implements IDataExportService {
   exportPortfolioData(snapshots: PortfolioSnapshot[]): void {
@@ -17,6 +18,13 @@ export class CSVExportService implements IDataExportService {
 
     this.downloadCSV(portfolioCSV, 'portfolio_history.csv');
     this.downloadCSV(yearlyCSV, 'yearly_summary.csv');
+  }
+
+  /**
+   * Returns the yearly summary CSV content (for testing).
+   */
+  getYearlySummaryCSVContent(snapshots: PortfolioSnapshot[]): string {
+    return this.generateYearlySummaryCSV(snapshots);
   }
 
   private generatePortfolioHistoryCSV(snapshots: PortfolioSnapshot[]): string {
@@ -31,6 +39,9 @@ export class CSVExportService implements IDataExportService {
   }
 
   private generateYearlySummaryCSV(snapshots: PortfolioSnapshot[]): string {
+    const yearlySnapshots = this.getYearlySnapshots(snapshots);
+    const snapshotsByYear = this.getSnapshotsByYear(snapshots);
+
     const headers = [
       'Ano',
       'Quantidade Final',
@@ -39,17 +50,34 @@ export class CSVExportService implements IDataExportService {
       'Custo Acumulado BRL',
       'Preço Médio BRL',
       'Ganho/Perda Total BRL',
+      'Total de Operações',
+      'Ações Recebidas (Vesting)',
+      'Ações Vendidas',
+      'Variação Líquida',
+      'Valor das Vendas (BRL)',
+      'Custo de Aquisição (BRL)',
+      'Ganho/Perda de Capital',
+      'Preço Médio Final (USD)',
+      'Preço Médio Final (BRL)',
+      'PTAX Média Venda',
+      'Resumo para Imposto de Renda (valor 31/12)',
+      'Bens e Direitos',
+      'Localização (País)',
+      'Discriminação',
+      'Negociado em bolsa',
+      'Código da Negociação',
+      'Situação em 31/12',
+      'Lucro ou Prejuízo',
     ];
-
-    // Get last snapshot per year
-    const yearlySnapshots = this.getYearlySnapshots(snapshots);
 
     const rows = Array.from(yearlySnapshots.entries())
       .sort(([a], [b]) => a - b)
-      .map(([year, snapshot]) => {
-        const position = snapshot.position;
-        
-        return [
+      .map(([year, lastSnapshot]) => {
+        const yearSnapshotsList = snapshotsByYear.get(year) ?? [lastSnapshot];
+        const summary = computeYearSummary(year, yearSnapshotsList);
+
+        const position = lastSnapshot.position;
+        const baseRow = [
           year.toString(),
           position.quantity.value.toString(),
           position.totalCostUsd.amount.toFixed(4),
@@ -58,9 +86,50 @@ export class CSVExportService implements IDataExportService {
           position.averagePriceBrl.amount.toFixed(4),
           position.grossProfitBrl.amount.toFixed(4),
         ];
+
+        if (!summary) {
+          const emptyCells = new Array(headers.length - baseRow.length).fill('');
+          return [...baseRow, ...emptyCells];
+        }
+
+        return [
+          ...baseRow,
+          summary.totalOperations.toString(),
+          summary.totalVested.toString(),
+          summary.totalSold.toString(),
+          summary.netChange.toString(),
+          summary.totalSaleRevenue.toFixed(4),
+          summary.totalCostBasis.toFixed(4),
+          summary.totalProfitLoss.toFixed(4),
+          summary.finalAvgPriceUsd.toFixed(4),
+          summary.finalAvgPriceBrl.toFixed(4),
+          summary.avgPtaxAsk.toFixed(4),
+          summary.totalCostBrl.toFixed(4),
+          summary.irpfBensEDireitos,
+          summary.irpfLocalizacao,
+          summary.irpfDiscriminacao,
+          summary.irpfNegociadoEmBolsa,
+          summary.irpfCodigoNegociacao,
+          summary.irpfSituacao3112,
+          summary.irpfLucroOuPrejuizo,
+        ];
       });
 
     return this.arrayToCSV([headers, ...rows]);
+  }
+
+  private getSnapshotsByYear(snapshots: PortfolioSnapshot[]): Map<number, PortfolioSnapshot[]> {
+    const byYear = new Map<number, PortfolioSnapshot[]>();
+    for (const snapshot of snapshots) {
+      const year = snapshot.position.lastUpdated.getFullYear();
+      const list = byYear.get(year) ?? [];
+      list.push(snapshot);
+      byYear.set(year, list);
+    }
+    for (const list of byYear.values()) {
+      list.sort((a, b) => a.position.lastUpdated.getTime() - b.position.lastUpdated.getTime());
+    }
+    return byYear;
   }
 
   private getYearlySnapshots(snapshots: PortfolioSnapshot[]): Map<number, PortfolioSnapshot> {

--- a/src/infrastructure/services/__tests__/CSVExportService.test.ts
+++ b/src/infrastructure/services/__tests__/CSVExportService.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { CSVExportService } from '../CSVExportService';
+import { ProcessPortfolioUseCase } from '../../../application/usecases/ProcessPortfolioUseCase';
+import { PortfolioCalculationService } from '../../../domain/services/PortfolioCalculationService';
+import { PortfolioAnalyticsService } from '../../../domain/services/PortfolioAnalyticsService';
+import { MockExchangeRateService } from '../MockExchangeRateService';
+import { JSONOperationRepository } from '../../repositories/JSONOperationRepository';
+
+function makeSnapshots(ops: string) {
+  const opRepo = new JSONOperationRepository(ops);
+  const exchangeService = new MockExchangeRateService(5.0);
+  const calcService = new PortfolioCalculationService(exchangeService);
+  const analyticsService = new PortfolioAnalyticsService();
+  const uc = new ProcessPortfolioUseCase(opRepo, calcService, analyticsService);
+  return uc.execute({}).then((r) => r.snapshots);
+}
+
+describe('CSVExportService', () => {
+  describe('getYearlySummaryCSVContent', () => {
+    it('includes extended year-detail columns in header', async () => {
+      const json = JSON.stringify([
+        { type: 'vesting', date: '01/15/2023', quantity: 100, price: 10 },
+      ]);
+      const snapshots = await makeSnapshots(json);
+      const service = new CSVExportService();
+      const csv = service.getYearlySummaryCSVContent(snapshots);
+
+      const headerLine = csv.split('\n')[0] ?? '';
+      expect(headerLine).toContain('Total de Operações');
+      expect(headerLine).toContain('Ações Recebidas (Vesting)');
+      expect(headerLine).toContain('Ações Vendidas');
+      expect(headerLine).toContain('Variação Líquida');
+      expect(headerLine).toContain('Valor das Vendas (BRL)');
+      expect(headerLine).toContain('Custo de Aquisição (BRL)');
+      expect(headerLine).toContain('Ganho/Perda de Capital');
+      expect(headerLine).toContain('PTAX Média Venda');
+      expect(headerLine).toContain('Bens e Direitos');
+      expect(headerLine).toContain('Discriminação');
+    });
+
+    it('outputs one data row per year with summary values', async () => {
+      const json = JSON.stringify([
+        { type: 'vesting', date: '01/15/2023', quantity: 100, price: 10 },
+        { type: 'trade', date: '06/10/2023', quantity: 50, price: 15 },
+      ]);
+      const snapshots = await makeSnapshots(json);
+      const service = new CSVExportService();
+      const csv = service.getYearlySummaryCSVContent(snapshots);
+
+      const lines = csv.split('\n');
+      expect(lines.length).toBeGreaterThanOrEqual(2);
+      expect(lines[0]).toContain('Ano');
+      expect(lines[1]).toContain('2023');
+      expect(lines[1]).toContain('2');
+      expect(lines[1]).toContain('100');
+      expect(lines[1]).toContain('50');
+    });
+  });
+});

--- a/src/presentation/components/ResultsSection.tsx
+++ b/src/presentation/components/ResultsSection.tsx
@@ -1,4 +1,5 @@
 import { type ProcessPortfolioResponse } from '@/application/usecases';
+import { computeYearSummary } from '@/application/services';
 import { type PortfolioSnapshot, type PortfolioPosition } from '@/domain/entities';
 import { BRLFormatter, USDFormatter, DateFormatter } from '@/presentation/formatters';
 import { useAnalytics } from '@/presentation/hooks';
@@ -226,16 +227,22 @@ export function ResultsSection({ response, snapshots, initialPosition, onReset }
           }}
         />
       )}
-      {selectedYear !== null && (
-        <YearDetailModal
-          year={selectedYear}
-          yearSnapshots={snapshots.filter((s) => s.position.lastUpdated.getFullYear() === selectedYear)}
-          onClose={() => {
-            analytics.trackEvent('year_detail_closed', { year: selectedYear });
-            setSelectedYear(null);
-          }}
-        />
-      )}
+      {selectedYear !== null && (() => {
+        const yearSnapshots = snapshots.filter((s) => s.position.lastUpdated.getFullYear() === selectedYear);
+        const summary = computeYearSummary(selectedYear, yearSnapshots);
+        if (!summary) return null;
+        return (
+          <YearDetailModal
+            year={selectedYear}
+            yearSnapshots={yearSnapshots}
+            summary={summary}
+            onClose={() => {
+              analytics.trackEvent('year_detail_closed', { year: selectedYear });
+              setSelectedYear(null);
+            }}
+          />
+        );
+      })()}
     </div>
   );
 }

--- a/src/presentation/components/YearDetailModal.tsx
+++ b/src/presentation/components/YearDetailModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { type PortfolioSnapshot } from '@/domain/entities';
+import { type YearSummary } from '@/application/services';
 import { BRLFormatter, USDFormatter, DateFormatter } from '@/presentation/formatters';
 import { useAnalytics } from '@/presentation/hooks';
 import { Modal, ModalHeader, ModalBody } from './Modal';
@@ -7,107 +8,53 @@ import { Modal, ModalHeader, ModalBody } from './Modal';
 interface YearDetailModalProps {
   year: number;
   yearSnapshots: PortfolioSnapshot[];
+  summary: YearSummary;
   onClose: () => void;
 }
 
-export function YearDetailModal({ year, yearSnapshots, onClose }: YearDetailModalProps) {
-  const firstSnapshot = yearSnapshots[0];
-  const lastSnapshot = yearSnapshots[yearSnapshots.length - 1];
-
-  if (!firstSnapshot || !lastSnapshot) return null;
-
-  const finalPosition = lastSnapshot.position;
-  const initialPosition = firstSnapshot.previousPosition;
-
-  const vestings = yearSnapshots.filter((s) => s.metadata.isVesting);
-  const trades = yearSnapshots.filter((s) => s.metadata.isTrade);
-
-  const totalVested = vestings.reduce((sum, s) => sum + s.metadata.quantity.value, 0);
-  const totalSold = trades.reduce((sum, s) => sum + s.metadata.quantity.value, 0);
-
-  const totalProfitLoss = trades.reduce(
-    (sum, s) => sum + (s.metadata.tradeFinancials?.profitLossBrl.amount ?? 0),
-    0
-  );
-
-  const totalSaleRevenue = trades.reduce(
-    (sum, t) => sum + (t.metadata.tradeFinancials?.saleRevenueBrl.amount ?? 0),
-    0
-  );
-  const totalCostBasis = trades.reduce(
-    (sum, t) => sum + (t.metadata.tradeFinancials?.costBasisBrl.amount ?? 0),
-    0
-  );
-
-  const avgPtaxAsk =
-    yearSnapshots.reduce((sum, s) => sum + s.metadata.exchangeRates.ptaxAsk, 0) /
-    yearSnapshots.length;
-
-  const initialQty = initialPosition?.quantity.value ?? 0;
-  const finalQty = finalPosition.quantity.value;
-  const netChange = finalQty - initialQty;
-
-  const currentYear = new Date().getFullYear();
-  const isCurrentYear = year === currentYear;
-  const isFutureYear = year > currentYear;
-  const yearInProgress = isCurrentYear || isFutureYear;
-
+export function YearDetailModal({ year, yearSnapshots, summary, onClose }: YearDetailModalProps) {
   return (
     <Modal onClose={onClose} large>
       <ModalHeader title={`Detalhes do Ano ${year}`} onClose={onClose} />
       <ModalBody>
         <div className="space-y-6">
           {/* Year-in-progress banner */}
-          {yearInProgress && <YearInProgressBanner isCurrentYear={isCurrentYear} />}
+          {summary.yearInProgress && <YearInProgressBanner isCurrentYear={summary.isCurrentYear} />}
 
           {/* Hero: key numbers at a glance */}
           <HeroSection
-            finalQty={finalQty}
-            totalCostBrl={finalPosition.totalCostBrl.amount}
-            totalProfitLoss={totalProfitLoss}
-            yearInProgress={yearInProgress}
-            isCurrentYear={isCurrentYear}
+            finalQty={summary.finalQty}
+            totalCostBrl={summary.totalCostBrl}
+            totalProfitLoss={summary.totalProfitLoss}
+            yearInProgress={summary.yearInProgress}
+            isCurrentYear={summary.isCurrentYear}
             year={year}
           />
 
           {/* Activity breakdown */}
-          <ActivitySection
-            snapshots={yearSnapshots}
-            vestings={vestings}
-            trades={trades}
-            totalVested={totalVested}
-            totalSold={totalSold}
-            initialQty={initialQty}
-            finalQty={finalQty}
-            netChange={netChange}
-          />
+          <ActivitySection summary={summary} />
 
           {/* Financial summary (only if trades exist) */}
-          {trades.length > 0 && (
+          {summary.tradeCount > 0 && (
             <FinancialSection
-              totalSaleRevenue={totalSaleRevenue}
-              totalCostBasis={totalCostBasis}
-              totalProfitLoss={totalProfitLoss}
+              totalSaleRevenue={summary.totalSaleRevenue}
+              totalCostBasis={summary.totalCostBasis}
+              totalProfitLoss={summary.totalProfitLoss}
             />
           )}
 
           {/* Position & pricing */}
           <PositionSection
-            finalPosition={finalPosition}
-            avgPtaxAsk={avgPtaxAsk}
+            finalAvgPriceUsd={summary.finalAvgPriceUsd}
+            finalAvgPriceBrl={summary.finalAvgPriceBrl}
+            avgPtaxAsk={summary.avgPtaxAsk}
           />
 
           {/* Operations table */}
           <OperationsTable snapshots={yearSnapshots} />
 
           {/* Tax summary */}
-          <TaxSummary
-            year={year}
-            yearSnapshots={yearSnapshots}
-            totalProfitLoss={totalProfitLoss}
-            yearInProgress={yearInProgress}
-            isCurrentYear={isCurrentYear}
-          />
+          <TaxSummary summary={summary} year={year} />
         </div>
       </ModalBody>
     </Modal>
@@ -231,51 +178,33 @@ function HeroSection({
    Activity Section — operations overview
    ================================================================ */
 
-function ActivitySection({
-  snapshots,
-  vestings,
-  trades,
-  totalVested,
-  totalSold,
-  initialQty,
-  finalQty,
-  netChange,
-}: {
-  snapshots: PortfolioSnapshot[];
-  vestings: PortfolioSnapshot[];
-  trades: PortfolioSnapshot[];
-  totalVested: number;
-  totalSold: number;
-  initialQty: number;
-  finalQty: number;
-  netChange: number;
-}) {
+function ActivitySection({ summary }: { summary: YearSummary }) {
   return (
     <div>
       <SectionLabel>Atividade do Ano</SectionLabel>
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <StatCard
           label="Total de Operações"
-          value={String(snapshots.length)}
-          detail={`${vestings.length} vestings · ${trades.length} vendas`}
+          value={String(summary.totalOperations)}
+          detail={`${summary.vestingCount} vestings · ${summary.tradeCount} vendas`}
         />
         <StatCard
           label="Ações Recebidas (Vesting)"
-          value={`+${totalVested}`}
-          detail={`${vestings.length} operações`}
+          value={`+${summary.totalVested}`}
+          detail={`${summary.vestingCount} operações`}
           variant="positive"
         />
         <StatCard
           label="Ações Vendidas"
-          value={totalSold > 0 ? `-${totalSold}` : '0'}
-          detail={`${trades.length} operações`}
-          variant={totalSold > 0 ? 'negative' : 'neutral'}
+          value={summary.totalSold > 0 ? `-${summary.totalSold}` : '0'}
+          detail={`${summary.tradeCount} operações`}
+          variant={summary.totalSold > 0 ? 'negative' : 'neutral'}
         />
         <StatCard
           label="Variação Líquida"
-          value={`${netChange >= 0 ? '+' : ''}${netChange}`}
-          detail={`${initialQty} → ${finalQty} ações`}
-          variant={netChange >= 0 ? 'positive' : 'negative'}
+          value={`${summary.netChange >= 0 ? '+' : ''}${summary.netChange}`}
+          detail={`${summary.initialQty} → ${summary.finalQty} ações`}
+          variant={summary.netChange >= 0 ? 'positive' : 'negative'}
         />
       </div>
     </div>
@@ -333,10 +262,12 @@ function FinancialSection({
    ================================================================ */
 
 function PositionSection({
-  finalPosition,
+  finalAvgPriceUsd,
+  finalAvgPriceBrl,
   avgPtaxAsk,
 }: {
-  finalPosition: PortfolioSnapshot['position'];
+  finalAvgPriceUsd: number;
+  finalAvgPriceBrl: number;
   avgPtaxAsk: number;
 }) {
   return (
@@ -345,12 +276,12 @@ function PositionSection({
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <StatCard
           label="Preço Médio Final (USD)"
-          value={USDFormatter.formatWithPrecision(finalPosition.averagePriceUsd.amount)}
+          value={USDFormatter.formatWithPrecision(finalAvgPriceUsd)}
           detail="Por ação"
         />
         <StatCard
           label="Preço Médio Final (BRL)"
-          value={BRLFormatter.formatWithPrecision(finalPosition.averagePriceBrl.amount)}
+          value={BRLFormatter.formatWithPrecision(finalAvgPriceBrl)}
           detail="Por ação"
         />
         <StatCard
@@ -450,61 +381,41 @@ function OperationsTable({ snapshots }: { snapshots: PortfolioSnapshot[] }) {
    Tax Summary — IRPF
    ================================================================ */
 
-function TaxSummary({
-  year,
-  yearSnapshots,
-  totalProfitLoss,
-  yearInProgress,
-  isCurrentYear,
-}: {
-  year: number;
-  yearSnapshots: PortfolioSnapshot[];
-  totalProfitLoss: number;
-  yearInProgress: boolean;
-  isCurrentYear: boolean;
-}) {
-  const lastSnapshot = yearSnapshots[yearSnapshots.length - 1];
-  const finalPosition = lastSnapshot?.position;
-  const totalCostBrl = finalPosition?.totalCostBrl.amount ?? 0;
-  const totalCostUsd = finalPosition?.totalCostUsd.amount ?? 0;
-  const finalQty = finalPosition?.quantity.value ?? 0;
-  const avgPriceBrl = finalPosition ? finalPosition.averagePriceBrl.amount : 0;
-  const avgPriceUsd = finalPosition ? finalPosition.averagePriceUsd.amount : 0;
-
-  const situationLabel = yearInProgress
-    ? `Situação Atual ${isCurrentYear ? '*' : '**'}`
+function TaxSummary({ summary, year }: { summary: YearSummary; year: number }) {
+  const situationLabel = summary.yearInProgress
+    ? `Situação Atual ${summary.isCurrentYear ? '*' : '**'}`
     : `Situação 31/12/${year}`;
-  const situationDetail = yearInProgress
-    ? isCurrentYear ? '* Ano em andamento' : '** Ano futuro'
+  const situationDetail = summary.yearInProgress
+    ? summary.isCurrentYear ? '* Ano em andamento' : '** Ano futuro'
     : 'Valor para declarar';
 
   return (
     <div>
-      <SectionLabel>Resumo para Imposto de Renda {year+1}</SectionLabel>
+      <SectionLabel>Resumo para Imposto de Renda {year + 1}</SectionLabel>
 
       {/* Key IRPF metrics */}
       <div className="mb-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <div className="rounded-xl border-2 border-brand-300 bg-brand-50/60 p-4 dark:border-brand-600 dark:bg-brand-950/30">
           <div className="text-xs font-medium text-brand-600 dark:text-brand-400">{situationLabel}</div>
-          <div className="text-xl font-bold text-surface-900 dark:text-surface-100">{BRLFormatter.formatWithPrecision(totalCostBrl)}</div>
+          <div className="text-xl font-bold text-surface-900 dark:text-surface-100">{BRLFormatter.format(summary.totalCostBrl)}</div>
           <div className="text-xs text-brand-500 dark:text-brand-400">{situationDetail}</div>
         </div>
         <div className="rounded-xl border border-surface-200 bg-surface-0 p-4 dark:border-surface-700 dark:bg-surface-800">
           <div className="text-xs text-surface-500 dark:text-surface-400">Ganho/Perda Total (BRL)</div>
-          <div className={`text-xl font-bold ${totalProfitLoss >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-rose-600 dark:text-rose-400'}`}>
-            {BRLFormatter.format(totalProfitLoss)}
+          <div className={`text-xl font-bold ${summary.totalProfitLoss >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-rose-600 dark:text-rose-400'}`}>
+            {BRLFormatter.format(summary.totalProfitLoss)}
           </div>
           <div className="text-xs text-surface-400">Resultado das vendas</div>
         </div>
         <div className="rounded-xl border border-surface-200 bg-surface-0 p-4 dark:border-surface-700 dark:bg-surface-800">
           <div className="text-xs text-surface-500 dark:text-surface-400">Ações em Carteira</div>
-          <div className="text-2xl font-bold text-surface-900 dark:text-surface-100">{finalQty}</div>
+          <div className="text-2xl font-bold text-surface-900 dark:text-surface-100">{summary.finalQty}</div>
           <div className="text-xs text-surface-400">Fim do período</div>
         </div>
         <div className="rounded-xl border border-surface-200 bg-surface-0 p-4 dark:border-surface-700 dark:bg-surface-800">
           <div className="text-xs text-surface-500 dark:text-surface-400">Preço Médio (BRL)</div>
           <div className="text-xl font-bold text-surface-900 dark:text-surface-100">
-            {BRLFormatter.formatWithPrecision(avgPriceBrl)}
+            {BRLFormatter.formatWithPrecision(summary.finalAvgPriceBrl)}
           </div>
           <div className="text-xs text-surface-400">Por ação</div>
         </div>
@@ -515,16 +426,13 @@ function TaxSummary({
         <h4 className="mb-4 font-semibold text-surface-900 dark:text-surface-100">Como Declarar no IRPF</h4>
 
         <div className="space-y-3 text-surface-700 dark:text-surface-300">
-          <IrpfField label="Bens e Direitos" value="Grupo 03 - Participações em sociedades, Código 01 - Ações (inclusive as listadas em bolsa)" />
-          <IrpfField label="Localização (País)" value="137 - Cayman, Ilhas" />
-          <IrpfField
-            label="Discriminação"
-            value={`NU - ${finalQty} Ações da empresa Nu Holdings Ltd. negociadas na Bolsa dos Estados Unidos através do código: NU, adquiridas pela corretora ETrade. Valor de custo em ${USDFormatter.formatWithPrecision(totalCostUsd)} ou ${BRLFormatter.formatWithPrecision(totalCostBrl)} com preço médio de ${USDFormatter.formatWithPrecision(avgPriceUsd)} ou ${BRLFormatter.formatWithPrecision(avgPriceBrl)} por ação.`}
-          />
-          <IrpfField label="Negociado em bolsa" value="Sim" />
-          <IrpfField label="Código da Negociação" value="NU" />
-          <IrpfField label={`Situação em 31/12/${year}`} value={BRLFormatter.formatWithPrecision(totalCostBrl)} />
-          <IrpfField label="Lucro ou Prejuízo" value={BRLFormatter.format(totalProfitLoss)} />
+          <IrpfField label="Bens e Direitos" value={summary.irpfBensEDireitos} />
+          <IrpfField label="Localização (País)" value={summary.irpfLocalizacao} />
+          <IrpfField label="Discriminação" value={summary.irpfDiscriminacao} />
+          <IrpfField label="Negociado em bolsa" value={summary.irpfNegociadoEmBolsa} />
+          <IrpfField label="Código da Negociação" value={summary.irpfCodigoNegociacao} />
+          <IrpfField label={`Situação em 31/12/${year}`} value={summary.irpfSituacao3112} />
+          <IrpfField label="Lucro ou Prejuízo" value={summary.irpfLucroOuPrejuizo} />
         </div>
 
         <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50/60 px-4 py-2.5 text-xs text-amber-700 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-300">


### PR DESCRIPTION
## Extend yearly_summary.csv with Detalhes do Ano columns

### Summary

When the user runs **"Processar e Exportar CSV"**, the existing `yearly_summary.csv` now includes the same summary information shown in the **Detalhes do Ano** modal. No new file is added and the operations table is not exported; everything is in one row per year.

### Approach (Option B)

- **Shared logic**: Introduced an application-level `YearSummary` type and `computeYearSummary(year, yearSnapshots)` so both the CSV export and the Detalhes do Ano modal use the same data.
- **Modal refactor**: The modal no longer derives year-detail data; it receives a precomputed `summary` from `ResultsSection` and only renders it (plus the operations table from `yearSnapshots`).

### Changes

**Application**

- **`src/application/services/YearSummary.ts`** (new): Defines `YearSummary` and `computeYearSummary()`. Computes activity (total operations, vested/sold, net change), financials (sale revenue, cost basis, P&amp;L), position (avg prices, PTAX), and IRPF copyable strings using `Intl` (no presentation dependency).
- **`src/application/services/index.ts`** (new): Exports `YearSummary` and `computeYearSummary`.

**Presentation**

- **`ResultsSection.tsx`**: When opening the year modal, computes `summary = computeYearSummary(selectedYear, yearSnapshots)` and passes `summary` into `YearDetailModal` (only renders modal when `summary` is non-null).
- **`YearDetailModal.tsx`**: Requires `summary: YearSummary`. Removed inline derivation; Hero, Activity, Financial, Position, and TaxSummary read from `summary`. Operations table still uses `yearSnapshots`. IRPF copyable fields use `summary.irpf*`.

**Infrastructure**

- **`CSVExportService.ts`**: Added `getSnapshotsByYear()` to group snapshots by year. Extended `generateYearlySummaryCSV()` to call `computeYearSummary()` per year and append the new columns to each row. Added `getYearlySummaryCSVContent()` for tests.

### New columns in yearly_summary.csv

- **Activity**: Total de Operações, Ações Recebidas (Vesting), Ações Vendidas, Variação Líquida  
- **Financial**: Valor das Vendas (BRL), Custo de Aquisição (BRL), Ganho/Perda de Capital  
- **Position**: Preço Médio Final (USD), Preço Médio Final (BRL), PTAX Média Venda  
- **IRPF**: Resumo para Imposto de Renda (valor 31/12), Bens e Direitos, Localização (País), Discriminação, Negociado em bolsa, Código da Negociação, Situação em 31/12, Lucro ou Prejuízo  

### Testing

- **`application/services/__tests__/YearSummary.test.ts`**: `computeYearSummary` for empty snapshots (null), year with only vestings, and year with vestings + trades (totals and IRPF strings).
- **`infrastructure/services/__tests__/CSVExportService.test.ts`**: Yearly summary CSV header includes the new columns; one row per year with expected summary values.

All existing tests pass; build succeeds.